### PR TITLE
Java 11 support: replacing javax.xml.bind import with an equivalent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
-jdk: openjdk7
+jdk: 
+  - openjdk7
+  - oraclejdk11
 script: 
   - export _JAVA_OPTIONS="-Xmx512m -Xms256m"
   - mvn clean install

--- a/kount-access-java-sdk/src/main/java/com/kount/kountaccess/AccessSdk.java
+++ b/kount-access-java-sdk/src/main/java/com/kount/kountaccess/AccessSdk.java
@@ -6,11 +6,10 @@ import java.net.UnknownHostException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import javax.xml.bind.DatatypeConverter;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;
@@ -836,7 +835,7 @@ public class AccessSdk {
 		}
 		String header = merchantId + ":" + apiKey;
 		try {
-			authorizationHeader = "Basic " + DatatypeConverter.printBase64Binary(header.getBytes("UTF8"));
+			authorizationHeader = "Basic " + Base64.getEncoder().encodeToString(header.getBytes("UTF-8"));
 			return authorizationHeader;
 		} catch (UnsupportedEncodingException e) {
 			logger.warn("Could not create authorization header", e);

--- a/kount-access-java-sdk/src/main/java/com/kount/kountaccess/AccessSdk.java
+++ b/kount-access-java-sdk/src/main/java/com/kount/kountaccess/AccessSdk.java
@@ -7,11 +7,11 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;
 import org.apache.http.ParseException;
@@ -836,7 +836,7 @@ public class AccessSdk {
 		}
 
 		String header = merchantId + ":" + apiKey;
-		authorizationHeader = "Basic " + Base64.getEncoder().encodeToString(header.getBytes(StandardCharsets.UTF_8));
+		authorizationHeader = "Basic " + Base64.encodeBase64String(header.getBytes(StandardCharsets.UTF_8));
 		return authorizationHeader;
 	}
 

--- a/kount-access-java-sdk/src/main/java/com/kount/kountaccess/AccessSdk.java
+++ b/kount-access-java-sdk/src/main/java/com/kount/kountaccess/AccessSdk.java
@@ -3,6 +3,7 @@ package com.kount.kountaccess;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -833,14 +834,10 @@ public class AccessSdk {
 		if (authorizationHeader != null) {
 			return authorizationHeader;
 		}
+
 		String header = merchantId + ":" + apiKey;
-		try {
-			authorizationHeader = "Basic " + Base64.getEncoder().encodeToString(header.getBytes("UTF-8"));
-			return authorizationHeader;
-		} catch (UnsupportedEncodingException e) {
-			logger.warn("Could not create authorization header", e);
-		}
-		return null;
+		authorizationHeader = "Basic " + Base64.getEncoder().encodeToString(header.getBytes(StandardCharsets.UTF_8));
+		return authorizationHeader;
 	}
 
 	/**


### PR DESCRIPTION
* replaced `javax.xml.bind.DatatypeConverter` with ~`java.util.Base64`~ `commons-codec:Base64`
* using `StandardCharsets.UTF_8` instead of just `"UTF-8"`
* removed unused code